### PR TITLE
Update weatherentity.yaml

### DIFF
--- a/weatherentity.yaml
+++ b/weatherentity.yaml
@@ -1,5 +1,5 @@
 widget_type: base_weatherentity
-entity: {{entity}}
+entity: "{{entity}}"
 fields:
   title: ""
   show_forecast: 0


### PR DESCRIPTION
On recent versions it throws an error without the double quotes: [reference](https://community.home-assistant.io/t/custom-hadashboard-widgets-stopped-working-after-appdaemon-4-upgrade-fixed-by-placing-quotes-around-any-properties/166429)